### PR TITLE
Introduce interface in dnsmasq options

### DIFF
--- a/package/usr/local/lib/cluster-lab/clusterleader_lib
+++ b/package/usr/local/lib/cluster-lab/clusterleader_lib
@@ -63,18 +63,18 @@ interface=${CLUSTER_INTERFACE}
 
 dhcp-authoritative
 dhcp-leasefile=/var/lib/misc/dnsmasq.leases
-dhcp-option=1,${DHCP_NETMASK}
-dhcp-option=28,${DHCP_BROADCAST}
+dhcp-option=${CLUSTER_INTERFACE},1,${DHCP_NETMASK}
+dhcp-option=${CLUSTER_INTERFACE},28,${DHCP_BROADCAST}
 
 # disable announcing gateway
-dhcp-option=3
+dhcp-option=${CLUSTER_INTERFACE},3
 # disable announcing dns server
-dhcp-option=6
+dhcp-option=${CLUSTER_INTERFACE},6
 
 
 # dynamic DHCP range with a 1 hour lease
 #
-dhcp-range=${DHCP_RANGE_FROM},${DHCP_RANGE_TO},1h
+dhcp-range=${CLUSTER_INTERFACE},${DHCP_RANGE_FROM},${DHCP_RANGE_TO},1h
 
 EOM
 

--- a/package/usr/local/lib/cluster-lab/docker_lib
+++ b/package/usr/local/lib/cluster-lab/docker_lib
@@ -75,7 +75,7 @@ function configure_docker(){
   fi
 
   echo -e "$(eval "echo -e ${DOCKER_OPTS}")" > /etc/docker/daemon.json
-
+  systemctl daemon-reload
   systemctl restart docker.service
 }
 
@@ -86,6 +86,7 @@ function reset_docker(){
 
   if [[ -f "/etc/docker/daemon.json.cluster-lab-backup" ]]; then
     mv -f /etc/docker/daemon.json.cluster-lab-backup /etc/docker/daemon.json
+    systemctl daemon-reload
     systemctl restart docker.service
   fi
 }

--- a/package/usr/local/lib/cluster-lab/networking_lib
+++ b/package/usr/local/lib/cluster-lab/networking_lib
@@ -32,7 +32,7 @@ function ensure_node_ip_is_set(){
   if [[ -z "${NODE_IP}" ]]; then
     if [[ ("${ENABLE_DHCP}" == "true") && ( -z "$(get_ip_of_interface "${CLUSTER_INTERFACE}")" ) ]]; then
       ip link set dev "${CLUSTER_INTERFACE}" up > /dev/null 2>&1
-      timeout 3 dhclient "${CLUSTER_INTERFACE}"
+      timeout 10 dhclient "${CLUSTER_INTERFACE}"
     fi
 
     # try 3 times to get an ip address
@@ -245,7 +245,7 @@ function reset_networking(){
     ip addr flush dev "${CLUSTER_INTERFACE}"
     remove_ip_from_cluster_interface "${CLUSTER_LEADER_IP}"
   fi
-  
+
   if [[ "${ENABLE_VLAN}" == "true" ]]; then
     remove_vlan_interface
   fi


### PR DESCRIPTION
In preparation to configure dnsmasq in `/etc/dnsmasq.d/` in the future. Nevertheless, with this modification DHCP only listens on the specified cluster-lab interface.