### PR TITLE
Copy docker.service to systemd

### DIFF
--- a/package/usr/local/lib/cluster-lab/docker_lib
+++ b/package/usr/local/lib/cluster-lab/docker_lib
@@ -57,7 +57,7 @@ function configure_docker(){
 
   # create backup of /etc/docker/daemon.json config
   if [[ (! -f "/etc/systemd/system/docker.service") ]]; then
-    cp /lib/systemd/system/docker.service /etc/systemd/system/docker.service.cluster-lab-backup
+    cp /lib/systemd/system/docker.service /etc/systemd/system/docker.service
   fi
 
   if [[ (! -f "/etc/systemd/system/docker.service.cluster-lab-backup") ]]; then

--- a/package/usr/local/lib/cluster-lab/docker_lib
+++ b/package/usr/local/lib/cluster-lab/docker_lib
@@ -56,6 +56,10 @@ function configure_docker(){
   fi
 
   # create backup of /etc/docker/daemon.json config
+  if [[ (! -f "/etc/systemd/system/docker.service") ]]; then
+    cp /lib/systemd/system/docker.service /etc/systemd/system/docker.service.cluster-lab-backup
+  fi
+
   if [[ (! -f "/etc/systemd/system/docker.service.cluster-lab-backup") ]]; then
     cp /etc/systemd/system/docker.service /etc/systemd/system/docker.service.cluster-lab-backup
   fi


### PR DESCRIPTION
If `docker.service` is missing in `/etc/systemd/system/`, we copy it from `/lib/systemd/system/`.